### PR TITLE
修复 RTP 音频头解析并说明 AirPlay 音频路由限制

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ player.gstreamer.swing=true
 Supports both video and audio (alac + aac_eld) streams <br>
 Gstreamer installation is required (see https://github.com/gstreamer-java/gst1-java-core)
 
+AirPlay audio is routed by the sender OS. When an iPhone or iPad mirrors to this
+receiver, iOS/iPadOS may move playback audio from the device speaker to the
+AirPlay receiver. The receiver can play the audio it receives, but it cannot
+force the sender device speaker to play at the same time. Dual playback requires
+an additional sender-side or companion-device audio path outside the AirPlay
+receiver protocol.
+
 ### FFmpeg
 
 Supports only video stream because playback of aac_eld audio requires ffmpeg compilation with ```--enable-libfdk-aac```  <br>

--- a/server/src/main/java/com/github/serezhka/airplay/server/internal/decoder/AudioDecoder.java
+++ b/server/src/main/java/com/github/serezhka/airplay/server/internal/decoder/AudioDecoder.java
@@ -19,11 +19,9 @@ public class AudioDecoder extends MessageToMessageDecoder<ByteBuf> {
 
         int seqNumber = ((headerBytes[2] & 0xFF) << 8) | (headerBytes[3] & 0xFF);
 
-        long timestamp = (headerBytes[7] & 0xFF) | ((headerBytes[6] & 0xFF) << 8) |
-                ((headerBytes[5] & 0xFF) << 16) | ((headerBytes[4] & 0xFF) << 24);
+        long timestamp = readUnsignedIntBigEndian(headerBytes, 4);
 
-        long ssrc = (headerBytes[11] & 0xFF) | ((headerBytes[6] & 0xFF) << 8) |
-                ((headerBytes[9] & 0xFF) << 16) | ((headerBytes[8] & 0xFF) << 24);
+        long ssrc = readUnsignedIntBigEndian(headerBytes, 8);
 
         AudioPacket audioPacket = AudioPacket.builder()
                 .flag(flag)
@@ -36,5 +34,12 @@ public class AudioDecoder extends MessageToMessageDecoder<ByteBuf> {
                 .build();
         audioPacket.encodedAudio(packet -> msg.readBytes(packet, 0, msg.readableBytes()));
         out.add(audioPacket);
+    }
+
+    private static long readUnsignedIntBigEndian(byte[] bytes, int offset) {
+        return ((long) bytes[offset] & 0xFF) << 24 |
+                ((long) bytes[offset + 1] & 0xFF) << 16 |
+                ((long) bytes[offset + 2] & 0xFF) << 8 |
+                ((long) bytes[offset + 3] & 0xFF);
     }
 }

--- a/server/src/test/java/com/github/serezhka/airplay/server/internal/decoder/AudioDecoderTest.java
+++ b/server/src/test/java/com/github/serezhka/airplay/server/internal/decoder/AudioDecoderTest.java
@@ -28,9 +28,9 @@ class AudioDecoderTest {
         AudioPacket packet = (AudioPacket) result.get(0);
         assertEquals(96, packet.getType());
         assertEquals(128, packet.getFlag());
-        assertEquals(54528, packet.getSsrc());
+        assertEquals(0, packet.getSsrc());
         assertEquals(54905, packet.getSequenceNumber());
-        assertEquals(-1937058542, packet.getTimestamp()); // FIXME
+        assertEquals(2357908754L, packet.getTimestamp());
         assertEquals(1920, packet.getEncodedAudioSize());
     }
 }


### PR DESCRIPTION
## 摘要

本 PR 修复了 RTP 音频包头解析错误，并在 README 中补充说明 AirPlay 的音频路由限制：接收端可以播放收到的音频流，但无法强制 iPhone/iPad 在投屏时同时保持本机扬声器播放。

## 变更内容

- 将 RTP `timestamp` 和 `ssrc` 按 unsigned 32-bit big-endian 解析。
- 修复 `AudioDecoder` 中 SSRC 字节偏移错误。
- 更新 `AudioDecoderTest`，断言修正后的 timestamp 和 SSRC。
- 在 README 中说明：手机/平板本机是否继续出声由 iOS/iPadOS 音频路由决定，接收端无法单方面控制；若要双端同时播放，需要额外的音频通道。

## 原因

原实现中：

- `timestamp` 可能被解析成负数，测试里也留下了 `// FIXME`。
- `ssrc` 的第二个字节误用了 `headerBytes[6]`，实际应来自 RTP header 的第 8-11 字节。
- 用户容易把“手机/平板无声、电脑有声”理解成接收端 BUG，但这本质上是 AirPlay 发送端系统音频路由行为。

## 测试

执行：

```shell
./gradlew.bat :server:test --tests com.github.serezhka.airplay.server.internal.decoder.AudioDecoderTest